### PR TITLE
Allow the container to stop nicely by answer to Ctrl+C or docker-stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN apk add --no-cache \
  && rm -rf /tmp/* \
  && apk del build-deps
 
-CMD /usr/local/bin/run.sh
+CMD exec /usr/local/bin/run.sh
 VOLUME ["/data"]
 EXPOSE 8080


### PR DESCRIPTION
Because without `exec`, the bot process runs at PID 1 which has special behaviour on SIGTERM.
This prevents Ctrl+C to work or makes Docker do a `kill` after `stop` did not work.